### PR TITLE
Remove Duplicate Configuration Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # connmon
 
 ## v3.0.5
-### Updated on 2025-June-04
+### Updated on 2025-June-07
 ## About
 connmon is an internet connection monitoring tool for AsusWRT Merlin with charts for daily, weekly and monthly summaries.
 


### PR DESCRIPTION
Added/modified code to remove duplicate parameter key names found in the configuration file.
Getting some duplicate key values can cause "bad number" or "arithmetic syntax" errors.